### PR TITLE
Correct `from_specs/2` @spec

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -678,7 +678,7 @@ defmodule Flow do
       Flow.from_specs(specs)
 
   """
-  @spec from_specs([Supervisor.child_spec()], keyword()) :: t
+  @spec from_specs([Supervisor.child_spec() | | {module(), term()} | module()], keyword()) :: t
   def from_specs(producers, options \\ [])
 
   def from_specs([_ | _] = producers, options) do

--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -678,7 +678,7 @@ defmodule Flow do
       Flow.from_specs(specs)
 
   """
-  @spec from_specs([Supervisor.child_spec() | | {module(), term()} | module()], keyword()) :: t
+  @spec from_specs([Supervisor.child_spec() | {module(), term()} | module()], keyword()) :: t
   def from_specs(producers, options \\ [])
 
   def from_specs([_ | _] = producers, options) do


### PR DESCRIPTION
Dialyzer errors out if `from_specs/2` is given child specs in the tuple form (such as in the example code):

Dialyzer error:
```
The call:
Flow.from_specs([{SomeModule, [{:foo, _} | {:bar, _}, ...]}, ...], [
  {:max_demand, 150},
  ...
])

breaks the contract
([Supervisor.child_spec()], :elixir.keyword()) :: t()
```

The above was raised from the following code:

```
[{SomeModule, [foo: "xxx", bar: "yyy"]}]
|> Flow.from_specs(max_demand: 150)
|> # rest of pipeline
```

Assuming the above is correct, could it make sense to add a type to `Supervisor` that is `Supervisor.child_spec() | | {module(), term()} | module()` ?