### PR TITLE
Add init callback to MapReducer

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -563,7 +563,7 @@ defmodule Flow do
     * `:shutdown` - the shutdown time for this stage when the flow is shut down.
       The same as the `:shutdown` value in a Supervisor, defaults to 5000 milliseconds.
     * `:on_init` - a function invoked during the initialization of each stage.
-      The function receives a single argument in the for of `{i, total}` where:
+      The function receives a single argument in the form of `{i, total}` where:
       - `i` is the stage index
       - `total` is the total number of stages
 

--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -562,6 +562,10 @@ defmodule Flow do
     * `:buffer_size` - how many events to buffer, see `c:GenStage.init/1`
     * `:shutdown` - the shutdown time for this stage when the flow is shut down.
       The same as the `:shutdown` value in a Supervisor, defaults to 5000 milliseconds.
+    * `:on_init` - a function invoked during the initialization of each stage.
+      The function receives a single argument in the for of `{i, total}` where:
+      - `i` is the stage index
+      - `total` is the total number of stages
 
   All remaining options are sent during subscription, allowing developers
   to customize `:min_demand`, `:max_demand` and others.

--- a/lib/flow/map_reducer.ex
+++ b/lib/flow/map_reducer.ex
@@ -4,6 +4,10 @@ defmodule Flow.MapReducer do
 
   def init({type, opts, index, trigger, acc, reducer}) do
     Process.flag(:trap_exit, true)
+
+    {init_map_reducer, opts} = Keyword.pop(opts, :init_map_reducer, & &1)
+    init_map_reducer.({type, opts, index, trigger, acc, reducer})
+
     {type, {%{}, build_status(type, trigger), index, acc.(), reducer}, opts}
   end
 

--- a/lib/flow/map_reducer.ex
+++ b/lib/flow/map_reducer.ex
@@ -5,8 +5,8 @@ defmodule Flow.MapReducer do
   def init({type, opts, index, trigger, acc, reducer}) do
     Process.flag(:trap_exit, true)
 
-    {init_map_reducer, opts} = Keyword.pop(opts, :init_map_reducer, & &1)
-    init_map_reducer.({type, opts, index, trigger, acc, reducer})
+    {on_init, opts} = Keyword.pop(opts, :on_init, &(&1))
+    on_init.(index)
 
     {type, {%{}, build_status(type, trigger), index, acc.(), reducer}, opts}
   end

--- a/lib/flow/map_reducer.ex
+++ b/lib/flow/map_reducer.ex
@@ -5,7 +5,7 @@ defmodule Flow.MapReducer do
   def init({type, opts, index, trigger, acc, reducer}) do
     Process.flag(:trap_exit, true)
 
-    {on_init, opts} = Keyword.pop(opts, :on_init, &(&1))
+    {on_init, opts} = Keyword.pop(opts, :on_init, & &1)
     on_init.(index)
 
     {type, {%{}, build_status(type, trigger), index, acc.(), reducer}, opts}

--- a/lib/flow/materialize.ex
+++ b/lib/flow/materialize.ex
@@ -2,7 +2,7 @@ defmodule Flow.Materialize do
   @moduledoc false
 
   @compile :inline_list_funcs
-  @map_reducer_opts [:buffer_keep, :buffer_size, :dispatcher, :init_map_reducer]
+  @map_reducer_opts [:buffer_keep, :buffer_size, :dispatcher, :on_init]
   @supervisor_opts [:shutdown]
 
   def materialize(%Flow{producers: nil}, _, _, _) do

--- a/lib/flow/materialize.ex
+++ b/lib/flow/materialize.ex
@@ -2,7 +2,7 @@ defmodule Flow.Materialize do
   @moduledoc false
 
   @compile :inline_list_funcs
-  @map_reducer_opts [:buffer_keep, :buffer_size, :dispatcher]
+  @map_reducer_opts [:buffer_keep, :buffer_size, :dispatcher, :init_map_reducer]
   @supervisor_opts [:shutdown]
 
   def materialize(%Flow{producers: nil}, _, _, _) do


### PR DESCRIPTION
My use case for this feature is to allow setting logger metadata of the stage processes, including copying metadata from the parent process.

Apparently, the only way right now to do this is by checking the process dictionary and conditionally setting the logger metadata inside a `Flow.map` call. This is far from optimal if you just want to set the metadata once at the beginning of the whole flow, specially for large or infinite streams.

I haven't documented the new option yet because I'm not sure about the name (`init_map_reducer`) and I want to hear other opinions about the feature first.