### PR TITLE
Begin fixing Dialyzer errors.

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -466,7 +466,7 @@ defmodule Flow do
            | {:from_stages, (fun() -> [{GenStage.stage(), keyword}])}
            | {:through_stages, t, (fun() -> [{GenStage.stage(), keyword}])}
            | {:enumerables, Enumerable.t()}
-           | {:join, t, t, fun(), fun(), fun()}
+           | {:join, join, t, t, fun(), fun(), fun()}
            | {:departition, t, fun(), fun(), fun()}
            | {:flows, [t]}
 

--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -254,7 +254,15 @@ defmodule Flow.Window do
   between count windows and global windows with count triggers.
   """
 
-  @type t :: %{required(:trigger) => {fun(), fun()} | nil, required(:periodically) => [trigger]}
+  @type t :: %{
+          required(:trigger) => {fun(), fun()} | nil,
+          required(:periodically) => [trigger],
+          optional(:count) => non_neg_integer(),
+          optional(:lateness) => non_neg_integer(),
+          optional(:by) => by(),
+          optional(:duration) => non_neg_integer(),
+          optional(:__struct__) => module()
+        }
 
   @typedoc "The supported window types."
   @type type :: :global | :fixed | :periodic | :count | any()
@@ -486,6 +494,7 @@ defmodule Flow.Window do
     %{window | periodically: [trigger | periodically]}
   end
 
+  @spec to_ms(pos_integer(), time_unit()) :: pos_integer
   defp to_ms(count, :millisecond), do: count
   defp to_ms(count, :second), do: count * 1000
   defp to_ms(count, :minute), do: count * 1000 * 60

--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -257,11 +257,7 @@ defmodule Flow.Window do
   @type t :: %{
           required(:trigger) => {fun(), fun()} | nil,
           required(:periodically) => [trigger],
-          optional(:count) => non_neg_integer(),
-          optional(:lateness) => non_neg_integer(),
-          optional(:by) => by(),
-          optional(:duration) => non_neg_integer(),
-          optional(:__struct__) => module()
+          optional(atom()) => term()
         }
 
   @typedoc "The supported window types."


### PR DESCRIPTION
There are still several errors in `flow.ex` that I have not figured out yet, so I am uncomfortable adding Dialyzer to the travis script. 

Basically, all the `Flow.Window.count`, `bounded_join` and `windowed_join` and friends have extra keys that were not reflected in `Flow.Window.t()` which caused downstream Dialyzer errors whenever these functions are used. 